### PR TITLE
Options, be explicit when options are not defined correctly

### DIFF
--- a/lib/dobby/options.rb
+++ b/lib/dobby/options.rb
@@ -78,6 +78,7 @@ module Dobby
     def long_opt_symbol(args)
       long_opt = args.find { |arg| arg.start_with?('--') }
       raise "unable to find long option from '#{args}'" unless long_opt
+
       long_opt[2..-1].sub('[no-]', '').sub(/ .*/, '')
                      .tr('-', '_').gsub(/[\[\]]/, '').to_sym
     end

--- a/lib/dobby/options.rb
+++ b/lib/dobby/options.rb
@@ -77,6 +77,7 @@ module Dobby
     # e.g. [..., '--auto-correct', ...] to :auto_correct.
     def long_opt_symbol(args)
       long_opt = args.find { |arg| arg.start_with?('--') }
+      raise "unable to find long option from '#{args}'" unless long_opt
       long_opt[2..-1].sub('[no-]', '').sub(/ .*/, '')
                      .tr('-', '_').gsub(/[\[\]]/, '').to_sym
     end


### PR DESCRIPTION
The option method of Option currently expects for a long-form option to
always be provided. If one is not defined, long_opt_symbol will error
when it tries to slice nil. Instead, raise an error.