### PR TITLE
Add git support for Ubuntu strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## 0.1.3
+* Add support for the git Ubuntu CVE repository (instead of bazaar). ([@cameron-gagnon][])
+
+## 0.1.2
+* Gemspec: Fix executable specification ([@bannable][])
+
 ## 0.1.0
 
 Initial release. ([@bannable][])

--- a/spec/dobby/options_spec.rb
+++ b/spec/dobby/options_spec.rb
@@ -61,11 +61,13 @@ RSpec.describe Dobby::Options do
                                                the specified file instead of requesting the
                                                DST json file from a remote.
                   --releases ONE,TWO           Limit the packages returned by a VulnSource to
-                                               these releases. Default vaires with selected
+                                               these releases. Default varies with selected
                                                VulnSource.
-                  --bzr-bin PATH               VulnSource::Ubuntu - Path to the "bzr" binary.
+                  --git-bin PATH               VulnSource::Ubuntu - Path to the "git" binary.
+                  --local-repo PATH            VulnSource::Ubuntu - Path to the Ubuntu Security
+                                               git repo on the local filesystem
                   --tracker-repo URI           VulnSource::Ubuntu - Path to the security tracker
-                                               bazaar repository remote.
+                                               git repository remote.
                   --cve-url-prefix URL         URI prefix used for building CVE links.
         HELP
 

--- a/spec/dobby/vuln_source/ubuntu_spec.rb
+++ b/spec/dobby/vuln_source/ubuntu_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Dobby::VulnSource::Ubuntu do
 
   before(:each) do
     allow(src).to receive(:modified_entries) { test_data_path }
-    allow(src).to receive(:bzr_revno) { '1' }
-    allow(src).to receive(:branch_or_pull) { true }
+    allow(src).to receive(:git_commit) { '1' }
+    allow(src).to receive(:clone_or_pull) { true }
   end
 
   describe '#update' do
@@ -40,7 +40,7 @@ RSpec.describe Dobby::VulnSource::Ubuntu do
       it 'is true for a second update if something has changed' do
         subject.update
         expect do
-          allow(src).to receive(:bzr_revno).and_return('2')
+          allow(src).to receive(:git_commit).and_return('2')
         end.to change { subject.update.changed? }.from(false).to(true)
       end
     end
@@ -51,7 +51,9 @@ RSpec.describe Dobby::VulnSource::Ubuntu do
 
     context 'content format' do
       shared_examples_for 'a parsed ubuntu cve entry' do |versions|
-        let(:defect) { entries[pkg] }
+        let(:identifier) { 'CVE-2017-5430' }
+        let(:defect) { entries[pkg].find { |d| d.identifier == identifier } }
+
         it 'has CVE-2017-5430' do
           expect(defect.identifier).to eq('CVE-2017-5430')
         end


### PR DESCRIPTION
- The Ubuntu CVE repository is now a git repo instead of bazaar repo.
- Fix slight formatting issues that cause exceptions to occur preventing dobby
  from running to completion on Ubuntu hosts.